### PR TITLE
Added support for non-std::format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,10 @@ cmake_minimum_required(VERSION 3.12)
 project(borr VERSION 1.0.1 LANGUAGES CXX DESCRIPTION "Borr; A simple cross-platform C++ language file parser" HOMEPAGE_URL "https://github.com/SimonCahill")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(cmake/resources.cmake)
+include(cmake/format_support.cmake)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(
@@ -24,7 +26,7 @@ include_directories(
 
 file(GLOB_RECURSE FILES FOLLOW_SYMLINKS ${CMAKE_CURRENT_SOURCE_DIR} src/*.cpp)
 
-if (DEFINED liblangparser_BUILD_STATIC)
+if (DEFINED libborr_BUILD_STATIC)
     add_library(${PROJECT_NAME} STATIC ${FILES})
 else()
     add_library(${PROJECT_NAME} SHARED ${FILES})
@@ -34,6 +36,7 @@ target_link_libraries(
     ${PROJECT_NAME}
 
     # add potential dependencies here
+    ${FMT_LIB_NAME}
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC include/ ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/cmake/format_support.cmake
+++ b/cmake/format_support.cmake
@@ -14,13 +14,16 @@ if (DEFINED CXX_FORMAT_SUPPORT AND "${CXX_FORMAT_SUPPORT}" STREQUAL "1")
     message("std::format found! Lucky you!")
     set(FMT_LIB_NAME "")
 else()
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt-header-only
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG f5e54359df4c26b6230fc61d38aa294581393084
-    )
 
-    FetchContent_MakeAvailable(fmt-header-only)
+    if (NOT TARGET fmt-header-only)
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt-header-only
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG f5e54359df4c26b6230fc61d38aa294581393084
+        )
+        FetchContent_MakeAvailable(fmt-header-only)
+    endif()
+
     set(FMT_LIB_NAME "fmt::fmt-header-only")
 endif()

--- a/cmake/format_support.cmake
+++ b/cmake/format_support.cmake
@@ -1,0 +1,26 @@
+######################################################
+##  This CMake script tests for std::format support ##
+##  in the current environment.                     ##
+##  If std::format is not found, then it will       ##
+##  include libfmt into the project automatically.  ##
+##                                                  ##
+##  Copyright ©️ Simon Cahill                        ##
+######################################################
+
+include(CheckIncludeFileCXX)
+check_include_file_cxx("format" CXX_FORMAT_SUPPORT)
+
+if (DEFINED CXX_FORMAT_SUPPORT AND "${CXX_FORMAT_SUPPORT}" STREQUAL "1")
+    message("std::format found! Lucky you!")
+    set(FMT_LIB_NAME "")
+else()
+    include(FetchContent)
+    FetchContent_Declare(
+        fmt-header-only
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG f5e54359df4c26b6230fc61d38aa294581393084
+    )
+
+    FetchContent_MakeAvailable(fmt-header-only)
+    set(FMT_LIB_NAME "fmt::fmt-header-only")
+endif()

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -13,7 +13,11 @@
 /////////////////////
 // stl
 #include <chrono>
-#include <format>
+#if __cpp_lib_format >= 201907L
+#   include <format>
+#else
+#   include <fmt/format.h>
+#endif
 #include <filesystem>
 #include <fstream>
 #include <map>


### PR DESCRIPTION
This pull request adds support for [libfmt](https://github.com/fmtlib/fmt) when std::format isn't available.

An extra check is performed at configuration-time to see if fmt-header-only is already a target.  
If that's the case, then the library will use the existing fmt target instead.